### PR TITLE
Make ring request :headers keys be lowercase strings

### DIFF
--- a/src/ring/middleware/apigw.clj
+++ b/src/ring/middleware/apigw.clj
@@ -12,13 +12,19 @@
       (string/lower-case)
       (keyword)))
 
+(defn- keyword->lowercase-string [k]
+  (string/lower-case (name k)))
+
+(defn- map-keys [f m]
+  (into {} (map (fn [[k v]] [(f k) v]) m)))
+
 (defn- apigw-request->ring-request [apigw-request]
   {:pre [(every? #(contains? apigw-request %) [:httpMethod :path :queryStringParameters])
          (contains? #{"GET" "POST" "OPTIONS" "DELETE" "PUT"} (:httpMethod apigw-request))]}
   {:uri (:path apigw-request)
    :query-string (generate-query-string (:queryStringParameters apigw-request))
    :request-method (request->http-method apigw-request)
-   :headers (:headers apigw-request)})
+   :headers (map-keys keyword->lowercase-string (:headers apigw-request))})
 
 (defn- no-scheduled-route-configured-error [request]
   (throw (ex-info "Got Scheduled Event but no scheduled-event-route configured"
@@ -42,4 +48,3 @@
        {:statusCode (:status response)
         :headers (:headers response)
         :body (:body response)}))))
-


### PR DESCRIPTION
From https://github.com/ring-clojure/ring/wiki/Concepts#requests:

`:headers` A Clojure map of lowercase header name strings to corresponding
header value strings.

Without this change, the `:headers` map is not in a format that other
ring middlewares expect. For example, `wrap-json-params` which is used
in the README of this middleware expects there to be `content-type`
header, whereas with the same example keywordizing lambda invocation
payload and the current version of ring-apigw-lambda-proxy the `:headers`
map will end up containing key `:Content-Type`.