### PR TITLE
Allow request keys to be strings as well as keywords

### DIFF
--- a/src/ring/middleware/apigw.clj
+++ b/src/ring/middleware/apigw.clj
@@ -36,11 +36,14 @@
       scheduled-event? (no-scheduled-route-configured-error request)
       :else (apigw-request->ring-request request))))
 
+(defn- keywordify-request [request]
+  (into {} (map (fn [[k v]] [(keyword k) v]) request)))
+
 (defn wrap-apigw-lambda-proxy
   ([handler] (wrap-apigw-lambda-proxy handler {}))
   ([handler {:keys [scheduled-event-route]}]
    (fn [request]
-     (let [response (handler (apigw->ring-request request scheduled-event-route))]
+     (let [response (handler (apigw->ring-request (keywordify-request request) scheduled-event-route))]
        {:statusCode (:status response)
         :headers (:headers response)
         :body (:body response)}))))

--- a/test/ring/middleware/apigw_test.clj
+++ b/test/ring/middleware/apigw_test.clj
@@ -103,3 +103,15 @@
 
     (testing "invalid http method"
       (is (thrown-with-msg? AssertionError #"Assert failed: \(contains\? #\{\"DELETE\"" (app (->apigw-request "TEAPOT" "/failing")))))))
+
+(deftest when-called-with-strings-instead-of-keywords
+  (let [app (wrap-apigw-lambda-proxy ring-routes)
+        request   {"httpMethod" "GET"
+                   "path" "/get"
+                   "queryStringParameters" {(keyword "text") "hello, world!"
+                                            (keyword "foo[]") "bar"}
+                   "headers" {"X-Forwarded-For" "127.0.0.1, 127.0.0.2"
+                              "Accept-Language" "en-US,en;q=0.8"}}]
+
+    (is (= {:statusCode 200 :headers {} :body "get"}
+           (app request)))))


### PR DESCRIPTION
The documentation currently suggests converting the API Gateway JSON with `(cheshire/parse-stream "true")`. Unfortunately this converts *all* keys to keywords, including those in the `:headers` map. Existing Ring middleware expects keys in this map to be strings, not keywords.

In particular, I've been struggling to use https://github.com/r0man/ring-cors which gets confused when given keyword headers.

This change allows an API Gateway request with string keys to be handled (by only converting top-level keys to keywords).